### PR TITLE
udate(cli): document eps format and client naming

### DIFF
--- a/src/ts/tx2uml.ts
+++ b/src/ts/tx2uml.ts
@@ -25,7 +25,7 @@ The transaction hashes have to be in hexadecimal format with a 0x prefix. If run
     )
     .option(
         "-f, --outputFormat <value>",
-        "output file format: png, svg or puml",
+        "output file format: png, svg, eps or puml",
         "png"
     )
     .option(
@@ -38,7 +38,7 @@ The transaction hashes have to be in hexadecimal format with a 0x prefix. If run
     )
     .option(
         "-n, --nodeType <value>",
-        "geth (GoEthereum), tgeth (Turbo-Geth), openeth (OpenEthereum, previously Parity), nether (Nethermind), besu (Hyperledger Besu). Can also be set with the ARCHIVE_NODE_TYPE env var.",
+        "geth (GoEthereum), tgeth (Erigion,fka. Turbo-Geth), openeth (OpenEthereum, fka. Parity), nether (Nethermind), besu (Hyperledger Besu). Can also be set with the ARCHIVE_NODE_TYPE env var.",
         "geth"
     )
     .option("-p, --noParams", "Hide function params and return values.", false)


### PR DESCRIPTION
### Update Command Line Help information 

1. `eps` is a supported file format, but not described in the current CLI help. 

2. Also update Turbo Geth name to 'Erigion'.

#### Additional 'issue'

Additionally testing this locally produced an error message
```bash
 Output format uml is not supported. Only the following formats are supported: png,svg,eps.
```
Which is produced here https://github.com/naddison36/tx2uml/blob/8b03882868819cd53b7ff6b6ecd59cfd7c0fe8ce/src/ts/fileGenerator.ts#L35

and here is where its being read from:
https://github.com/naddison36/tx2uml/blob/8b03882868819cd53b7ff6b6ecd59cfd7c0fe8ce/src/ts/plantuml.ts#L6

a fix would be just to hardcode the format support of puml in the error message obv. Did not want to do anything as I am not sure how you would want to handle it.


