### PR TITLE
Feat: better debug output and coverage (#14)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: '96...100'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,39 @@
+# CI for command line NodeJS Applications
+name: nodejs
+on:
+  push:
+     paths:
+      - "**/**"
+      - "!**/*.md/**"
+
+env:
+  CI: true
+  FORCE_COLOR: 2
+
+jobs:
+  pipeline:
+    name: Node ${{ matrix.node }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['14.x', '16.x']
+        os: ['ubuntu-latest', 'macos-latest']
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2.3.5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2.4.1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install npm dependencies
+        run: npm install
+        id: install
+
+      - name: Run build
+        run: npm run build
+        id: build

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,13 @@ logs
 *.dot
 testDiagrams
 package-lock.json
+*.log
+output.png
+coverage/
+.nyc*
+.cache/
+build/
+.DS_Store
+dist/
+.env*
+!.env.example

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,4 @@
 lib
+coverage/
+*.html
+*.css

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-// jest.config.js
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
   verbose: true,
   transform: {
@@ -8,6 +8,14 @@ module.exports = {
     "/build/",
     "/node_modules/",
   ],
+  "collectCoverageFrom": [
+    "**/*.{ts,tsx}",
+    "!**/node_modules/**",
+    "!**/vendor/**",
+    "!**/lib/*"
+  ],
+  "coverageReporters": ["text", "json", "lcov", ["text-summary"]],
+
   testRegex: '/__tests__/.*\\.test\\.ts$',
   moduleFileExtensions: [
     'ts',

--- a/lib/clients/EthereumNodeClient.js
+++ b/lib/clients/EthereumNodeClient.js
@@ -4,7 +4,7 @@ const ethers_1 = require("ethers");
 const verror_1 = require("verror");
 const ABIs_1 = require("./ABIs");
 const regEx_1 = require("../utils/regEx");
-require("axios-debug-log");
+require("axios-debug-log/enable");
 const debug = require("debug")("tx2uml");
 const tokenInfoAddress = "0xbA51331Bf89570F3f55BC26394fcCA05d4063C71";
 class EthereumNodeClient {

--- a/lib/clients/EtherscanClient.js
+++ b/lib/clients/EtherscanClient.js
@@ -1,12 +1,10 @@
 "use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
-const axios_1 = __importDefault(require("axios"));
+const axios = require("axios").default;
 const ethers_1 = require("ethers");
 const verror_1 = require("verror");
 const regEx_1 = require("../utils/regEx");
+require("axios-debug-log/enable");
 const debug = require("debug")("tx2uml");
 const etherscanBaseUrls = {
     mainnet: "https://api.etherscan.io/api",
@@ -27,7 +25,7 @@ class EtherscanClient {
     async getContract(contractAddress) {
         var _a, _b;
         try {
-            const response = await axios_1.default.get(this.url, {
+            const response = await axios.get(this.url, {
                 params: {
                     module: "contract",
                     action: "getsourcecode",
@@ -76,7 +74,7 @@ class EtherscanClient {
             throw new TypeError(`Contract address "${contractAddress}" must be 20 bytes in hexadecimal format with a 0x prefix`);
         }
         try {
-            const response = await axios_1.default.get(this.url, {
+            const response = await axios.get(this.url, {
                 params: {
                     module: "token",
                     action: "tokeninfo",

--- a/lib/clients/GethClient.js
+++ b/lib/clients/GethClient.js
@@ -4,14 +4,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.parseReasonCode = void 0;
-const axios_1 = __importDefault(require("axios"));
+const axios = require("axios").default;
 const ethers_1 = require("ethers");
 const verror_1 = require("verror");
 const transaction_1 = require("../transaction");
 const regEx_1 = require("../utils/regEx");
 const utils_1 = require("ethers/lib/utils");
 const EthereumNodeClient_1 = __importDefault(require("./EthereumNodeClient"));
-require("axios-debug-log");
+require("axios-debug-log/enable");
 const debug = require("debug")("tx2uml");
 class GethClient extends EthereumNodeClient_1.default {
     constructor(url = "http://localhost:8545", chain = "mainnet") {
@@ -27,7 +27,7 @@ class GethClient extends EthereumNodeClient_1.default {
         }
         try {
             debug(`About to get transaction trace for ${txHash}`);
-            const response = await axios_1.default.post(this.url, {
+            const response = await axios.post(this.url, {
                 id: this.jsonRpcId++,
                 jsonrpc: "2.0",
                 method: "debug_traceTransaction",
@@ -76,9 +76,9 @@ class GethClient extends EthereumNodeClient_1.default {
                     data: tx.data,
                 },
                 // need to call for the block before
-                utils_1.hexlify(tx.blockNumber - 1).replace(/^0x0/, "0x"),
+                (0, utils_1.hexlify)(tx.blockNumber - 1).replace(/^0x0/, "0x"),
             ];
-            const response = await axios_1.default.post(this.url, {
+            const response = await axios.post(this.url, {
                 id: this.jsonRpcId++,
                 jsonrpc: "2.0",
                 method: "eth_call",
@@ -114,7 +114,7 @@ class GethClient extends EthereumNodeClient_1.default {
                     e.message);
             }
         }
-        return exports.parseReasonCode(rawMessageData);
+        return (0, exports.parseReasonCode)(rawMessageData);
     }
 }
 exports.default = GethClient;
@@ -192,7 +192,7 @@ const parseReasonCode = (messageData) => {
     // Using the length and known offset, extract and convert the revert reason
     const reasonCodeHex = messageData.slice(8 + 128, 8 + 128 + strLen * 2);
     // Convert reason from hex to string
-    const reason = utils_1.toUtf8String("0x" + reasonCodeHex);
+    const reason = (0, utils_1.toUtf8String)("0x" + reasonCodeHex);
     return reason;
 };
 exports.parseReasonCode = parseReasonCode;

--- a/lib/clients/OpenEthereumClient.js
+++ b/lib/clients/OpenEthereumClient.js
@@ -3,14 +3,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const axios_1 = __importDefault(require("axios"));
+const axios = require("axios").default;
 const ethers_1 = require("ethers");
 const verror_1 = require("verror");
 const transaction_1 = require("../transaction");
 const regEx_1 = require("../utils/regEx");
 const utils_1 = require("ethers/lib/utils");
 const EthereumNodeClient_1 = __importDefault(require("./EthereumNodeClient"));
-require("axios-debug-log");
+require("axios-debug-log/enable");
 const debug = require("debug")("tx2uml");
 class OpenEthereumClient extends EthereumNodeClient_1.default {
     constructor(url = "http://localhost:8545", network = "mainnet") {
@@ -26,7 +26,7 @@ class OpenEthereumClient extends EthereumNodeClient_1.default {
         }
         try {
             debug(`About to get transaction trace for ${txHash}`);
-            const response = await axios_1.default.post(this.url, {
+            const response = await axios.post(this.url, {
                 id: this.jsonRpcId++,
                 jsonrpc: "2.0",
                 method: "trace_replayTransaction",
@@ -136,9 +136,9 @@ class OpenEthereumClient extends EthereumNodeClient_1.default {
                     to: tx.to,
                     data: tx.data,
                 },
-                utils_1.hexlify(tx.blockNumber),
+                (0, utils_1.hexlify)(tx.blockNumber),
             ];
-            const response = await axios_1.default.post(this.url, {
+            const response = await axios.post(this.url, {
                 id: this.jsonRpcId++,
                 jsonrpc: "2.0",
                 method: "eth_call",

--- a/lib/fileGenerator.js
+++ b/lib/fileGenerator.js
@@ -11,13 +11,13 @@ const debug = require("debug")("tx2uml");
 const generateFile = async (pumlStream, options = {}) => {
     const filename = constructFilename(options.filename, options.format);
     try {
-        const outputStream = fs_1.createWriteStream(filename);
+        const outputStream = (0, fs_1.createWriteStream)(filename);
         if (options.format === "puml") {
             pumlStream.pipe(outputStream);
             debug(`Plant UML file written to ${filename} in raw puml format`);
         }
         else if (plantuml_1.outputFormats.includes(options.format)) {
-            await plantuml_1.streamPlantUml(pumlStream, outputStream, {
+            await (0, plantuml_1.streamPlantUml)(pumlStream, outputStream, {
                 format: options.format,
                 limitSize: 60000,
             });

--- a/lib/plantUmlStreamer.d.ts
+++ b/lib/plantUmlStreamer.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 import { Readable } from "stream";
 import { Contracts, Param, Trace, TransactionDetails } from "./transaction";
 export interface PumlGenerationOptions {

--- a/lib/plantUmlStreamer.js
+++ b/lib/plantUmlStreamer.js
@@ -15,23 +15,23 @@ const streamTxPlantUml = (transactions, traces, contracts, options = {}) => {
         read() { },
     });
     if (transactions.length > 1) {
-        exports.streamMultiTxsPuml(pumlStream, transactions, traces, contracts, options);
+        (0, exports.streamMultiTxsPuml)(pumlStream, transactions, traces, contracts, options);
     }
     else {
-        exports.streamSingleTxPuml(pumlStream, transactions[0], traces[0], contracts, options);
+        (0, exports.streamSingleTxPuml)(pumlStream, transactions[0], traces[0], contracts, options);
     }
     return pumlStream;
 };
 exports.streamTxPlantUml = streamTxPlantUml;
 const streamMultiTxsPuml = (pumlStream, transactions, traces, contracts, options = {}) => {
     pumlStream.push(`@startuml\n`);
-    exports.writeParticipants(pumlStream, contracts, options);
+    (0, exports.writeParticipants)(pumlStream, contracts, options);
     let i = 0;
     for (const transaction of transactions) {
         pumlStream.push(`\ngroup ${transaction.hash}`);
         writeTransactionDetails(pumlStream, transaction, options);
-        exports.writeMessages(pumlStream, traces[i++], options);
-        exports.writeEvents(pumlStream, contracts, options);
+        (0, exports.writeMessages)(pumlStream, traces[i++], options);
+        (0, exports.writeEvents)(pumlStream, contracts, options);
         pumlStream.push("end");
     }
     pumlStream.push("\n@endumls");
@@ -42,10 +42,10 @@ exports.streamMultiTxsPuml = streamMultiTxsPuml;
 const streamSingleTxPuml = (pumlStream, transaction, traces, contracts, options = {}) => {
     pumlStream.push(`@startuml\ntitle ${transaction.hash}\n`);
     pumlStream.push(genCaption(transaction, options));
-    exports.writeParticipants(pumlStream, contracts, options);
+    (0, exports.writeParticipants)(pumlStream, contracts, options);
     writeTransactionDetails(pumlStream, transaction, options);
-    exports.writeMessages(pumlStream, traces, options);
-    exports.writeEvents(pumlStream, contracts, options);
+    (0, exports.writeMessages)(pumlStream, traces, options);
+    (0, exports.writeEvents)(pumlStream, contracts, options);
     pumlStream.push("\n@endumls");
     pumlStream.push(null);
     return pumlStream;
@@ -69,8 +69,8 @@ const writeParticipants = (plantUmlStream, contracts, options = {}) => {
         if (contract.contractName) {
             name += `<<${contract.contractName}>>`;
         }
-        debug(`Write lifeline ${formatters_1.shortAddress(address)} with stereotype ${name}`);
-        plantUmlStream.push(`participant "${formatters_1.shortAddress(address)}" as ${formatters_1.participantId(address)} ${name}\n`);
+        debug(`Write lifeline ${(0, formatters_1.shortAddress)(address)} with stereotype ${name}`);
+        plantUmlStream.push(`participant "${(0, formatters_1.shortAddress)(address)}" as ${(0, formatters_1.participantId)(address)} ${name}\n`);
     }
 };
 exports.writeParticipants = writeParticipants;
@@ -78,7 +78,7 @@ const writeTransactionDetails = (plantUmlStream, transaction, options = {}) => {
     if (options.noTxDetails) {
         return;
     }
-    plantUmlStream.push(`\nnote over ${formatters_1.participantId(transaction.from)}`);
+    plantUmlStream.push(`\nnote over ${(0, formatters_1.participantId)(transaction.from)}`);
     if (transaction.error) {
         plantUmlStream.push(` ${FailureFillColor}\nError: ${transaction.error} \n`);
     }
@@ -87,11 +87,11 @@ const writeTransactionDetails = (plantUmlStream, transaction, options = {}) => {
         plantUmlStream.push("\n");
     }
     plantUmlStream.push(`Nonce: ${transaction.nonce.toLocaleString()}\n`);
-    plantUmlStream.push(`Gas Price: ${utils_1.formatUnits(transaction.gasPrice, "gwei")} Gwei\n`);
-    plantUmlStream.push(`Gas Limit: ${formatters_1.formatNumber(transaction.gasLimit.toString())}\n`);
-    plantUmlStream.push(`Gas Used: ${formatters_1.formatNumber(transaction.gasUsed.toString())}\n`);
+    plantUmlStream.push(`Gas Price: ${(0, utils_1.formatUnits)(transaction.gasPrice, "gwei")} Gwei\n`);
+    plantUmlStream.push(`Gas Limit: ${(0, formatters_1.formatNumber)(transaction.gasLimit.toString())}\n`);
+    plantUmlStream.push(`Gas Used: ${(0, formatters_1.formatNumber)(transaction.gasUsed.toString())}\n`);
     const txFeeInWei = transaction.gasUsed.mul(transaction.gasPrice);
-    const txFeeInEther = utils_1.formatEther(txFeeInWei);
+    const txFeeInEther = (0, utils_1.formatEther)(txFeeInWei);
     const tFeeInEtherFormatted = Number(txFeeInEther).toLocaleString();
     plantUmlStream.push(`Tx Fee: ${tFeeInEtherFormatted} ETH\n`);
     plantUmlStream.push("end note\n");
@@ -107,7 +107,7 @@ const writeMessages = (plantUmlStream, traces, options = {}) => {
     for (const trace of traces) {
         if (trace.depth > options.depth)
             continue;
-        debug(`Write message ${trace.id} from ${formatters_1.shortAddress(trace.from)} to ${formatters_1.shortAddress(trace.to)}`);
+        debug(`Write message ${trace.id} from ${(0, formatters_1.shortAddress)(trace.from)} to ${(0, formatters_1.shortAddress)(trace.to)}`);
         // return from lifeline if processing has moved to a different contract
         if (trace.delegatedFrom !== (previousTrace === null || previousTrace === void 0 ? void 0 : previousTrace.to)) {
             // contractCallStack is mutated in the loop so make a copy
@@ -121,16 +121,16 @@ const writeMessages = (plantUmlStream, traces, options = {}) => {
             }
         }
         if (trace.type === transaction_1.MessageType.Selfdestruct) {
-            plantUmlStream.push(`${formatters_1.participantId(trace.from)} ${genArrow(trace)} ${formatters_1.participantId(trace.from)}: Self-Destruct\n`);
+            plantUmlStream.push(`${(0, formatters_1.participantId)(trace.from)} ${genArrow(trace)} ${(0, formatters_1.participantId)(trace.from)}: Self-Destruct\n`);
             // TODO add ETH value transfer to refund address if there was a contract balance
         }
         else {
-            plantUmlStream.push(`${formatters_1.participantId(trace.from)} ${genArrow(trace)} ${formatters_1.participantId(trace.to)}: ${genFunctionText(trace, options.noParams)}${genGasUsage(trace.gasUsed, options.noGas)}${genEtherValue(trace, options.noEther)}\n`);
+            plantUmlStream.push(`${(0, formatters_1.participantId)(trace.from)} ${genArrow(trace)} ${(0, formatters_1.participantId)(trace.to)}: ${genFunctionText(trace, options.noParams)}${genGasUsage(trace.gasUsed, options.noGas)}${genEtherValue(trace, options.noEther)}\n`);
             if (trace.type === transaction_1.MessageType.DelegateCall) {
-                plantUmlStream.push(`activate ${formatters_1.participantId(trace.to)} ${DelegateLifelineColor}\n`);
+                plantUmlStream.push(`activate ${(0, formatters_1.participantId)(trace.to)} ${DelegateLifelineColor}\n`);
             }
             else {
-                plantUmlStream.push(`activate ${formatters_1.participantId(trace.to)}\n`);
+                plantUmlStream.push(`activate ${(0, formatters_1.participantId)(trace.to)}\n`);
             }
         }
         if (trace.type !== transaction_1.MessageType.Selfdestruct) {
@@ -150,19 +150,19 @@ const genEndLifeline = (trace, options = {}) => {
             plantUml += `return\n`;
         }
         else {
-            plantUml += `return${exports.genParams(trace.outputParams)}\n`;
+            plantUml += `return${(0, exports.genParams)(trace.outputParams)}\n`;
         }
         if (!options.noGas && trace.childTraces.length > 0) {
             const gasUsedLessChildCalls = calculateGasUsedLessChildTraces(trace);
             if (gasUsedLessChildCalls === null || gasUsedLessChildCalls === void 0 ? void 0 : gasUsedLessChildCalls.gt(0)) {
-                plantUml += `note right of ${formatters_1.participantId(trace.to)}: ${genGasUsage(gasUsedLessChildCalls)}\n`;
+                plantUml += `note right of ${(0, formatters_1.participantId)(trace.to)}: ${genGasUsage(gasUsedLessChildCalls)}\n`;
             }
         }
     }
     else {
         // a failed transaction so end the lifeline
-        plantUml += `destroy ${formatters_1.participantId(trace.to)}\nreturn\n`;
-        plantUml += `note right of ${formatters_1.participantId(trace.to)} ${FailureFillColor}: ${trace.error}\n`;
+        plantUml += `destroy ${(0, formatters_1.participantId)(trace.to)}\nreturn\n`;
+        plantUml += `note right of ${(0, formatters_1.participantId)(trace.to)} ${FailureFillColor}: ${trace.error}\n`;
     }
     return plantUml;
 };
@@ -205,7 +205,7 @@ const genFunctionText = (trace, noParams = false) => {
         }
         // If we have the contract ABI so the constructor params could be parsed
         if (trace.parsedConstructorParams) {
-            return `${trace.funcName}(${exports.genParams(trace.inputParams)})`;
+            return `${trace.funcName}(${(0, exports.genParams)(trace.inputParams)})`;
         }
         // we don't know if there was constructor params or not as the contract was not verified on Etherscan
         // hence we don't have the constructor params or the contract ABI to parse them.
@@ -219,7 +219,7 @@ const genFunctionText = (trace, noParams = false) => {
     }
     return noParams
         ? trace.funcName
-        : `${trace.funcName}(${exports.genParams(trace.inputParams)})`;
+        : `${trace.funcName}(${(0, exports.genParams)(trace.inputParams)})`;
 };
 const oneIndent = "  ";
 const genParams = (params, plantUml = "", indent = "") => {
@@ -234,12 +234,12 @@ const genParams = (params, plantUml = "", indent = "") => {
             plantUml += `${param.name}: `;
         }
         if (param.type === "address") {
-            plantUml += `${formatters_1.shortAddress(param.value)},`;
+            plantUml += `${(0, formatters_1.shortAddress)(param.value)},`;
         }
         else if (param.components) {
             if (Array.isArray(param.components)) {
                 plantUml += `[`;
-                plantUml = `${exports.genParams(param.components, plantUml, indent + oneIndent)}`;
+                plantUml = `${(0, exports.genParams)(param.components, plantUml, indent + oneIndent)}`;
                 plantUml += `],`;
             }
             else {
@@ -250,7 +250,7 @@ const genParams = (params, plantUml = "", indent = "") => {
             // not a component but an array of params
             plantUml += `[`;
             param.value.forEach((value, i) => {
-                plantUml = `${exports.genParams([
+                plantUml = `${(0, exports.genParams)([
                     {
                         name: i.toString(),
                         value,
@@ -262,10 +262,10 @@ const genParams = (params, plantUml = "", indent = "") => {
             plantUml += `],`;
         }
         else if (param.type.slice(0, 5) === "bytes") {
-            plantUml += `${formatters_1.shortBytes(param.value)},`;
+            plantUml += `${(0, formatters_1.shortBytes)(param.value)},`;
         }
         else if (param.type.match("int")) {
-            plantUml += `${formatters_1.formatNumber(param.value)},`;
+            plantUml += `${(0, formatters_1.formatNumber)(param.value)},`;
         }
         else {
             plantUml += `${param.value},`;
@@ -279,7 +279,7 @@ const genGasUsage = (gasUsed, noGasUsage = false) => {
         return "";
     }
     // Add thousand comma separators
-    const gasValueWithCommas = formatters_1.formatNumber(gasUsed.toString());
+    const gasValueWithCommas = (0, formatters_1.formatNumber)(gasUsed.toString());
     return `\\n${gasValueWithCommas} gas`;
 };
 const genEtherValue = (trace, noEtherValue = false) => {
@@ -287,7 +287,7 @@ const genEtherValue = (trace, noEtherValue = false) => {
         return "";
     }
     // Convert wei value to Ether
-    const ether = utils_1.formatEther(trace.value);
+    const ether = (0, utils_1.formatEther)(trace.value);
     // Add thousand commas. Can't use formatNumber for this as it doesn't handle decimal numbers.
     // Assuming the amount of ether is not great than JS number limit.
     const etherFormatted = Number(ether).toLocaleString();
@@ -305,10 +305,10 @@ const writeEvents = (plantUmlStream, contracts, options = {}) => {
         if (contract.ethersContract &&
             contract.events.length &&
             (options.depth === undefined || contract.minDepth <= options.depth)) {
-            plantUmlStream.push(`\nnote over ${formatters_1.participantId(contract.address)} #aqua`);
+            plantUmlStream.push(`\nnote over ${(0, formatters_1.participantId)(contract.address)} #aqua`);
             for (const event of contract.events) {
                 plantUmlStream.push(`\n${event.name}:`);
-                plantUmlStream.push(`${exports.genParams(event.params).replace(/\\n/g, "\n")}`);
+                plantUmlStream.push(`${(0, exports.genParams)(event.params).replace(/\\n/g, "\n")}`);
             }
             plantUmlStream.push("\nend note");
         }

--- a/lib/plantuml.js
+++ b/lib/plantuml.js
@@ -9,7 +9,7 @@ const path_1 = __importDefault(require("path"));
 const verror_1 = __importDefault(require("verror"));
 exports.outputFormats = ["png", "svg", "eps"];
 const streamPlantUml = async (pumlStream, outputStream, options = {}) => {
-    const pumlJavaOptions = exports.genPumlJavaOptions(options);
+    const pumlJavaOptions = (0, exports.genPumlJavaOptions)(options);
     return pipePuml(pumlStream, outputStream, pumlJavaOptions);
 };
 exports.streamPlantUml = streamPlantUml;
@@ -42,7 +42,7 @@ const genPumlJavaOptions = (options = {}) => {
 exports.genPumlJavaOptions = genPumlJavaOptions;
 const pipePuml = (pumlStream, outputStream, plantUmlOptions) => {
     return new Promise(async (resolve, reject) => {
-        const child = child_process_1.spawn("java", plantUmlOptions);
+        const child = (0, child_process_1.spawn)("java", plantUmlOptions);
         pumlStream.pipe(child.stdin);
         child.stdout.pipe(outputStream);
         let error = "";

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -96,7 +96,7 @@ class TransactionManager {
     async getContractsFromAddresses(addresses) {
         const contracts = {};
         // Get the contract details in parallel with a concurrency limit
-        const limit = p_limit_1.default(this.apiConcurrencyLimit);
+        const limit = (0, p_limit_1.default)(this.apiConcurrencyLimit);
         const getContractPromises = addresses.map(address => {
             return limit(() => this.etherscanClient.getContract(address));
         });

--- a/lib/tx2uml.d.ts
+++ b/lib/tx2uml.d.ts
@@ -1,2 +1,3 @@
 #! /usr/bin/env node
 export {};
+/** @exports tx2uml */

--- a/lib/tx2uml.js
+++ b/lib/tx2uml.js
@@ -11,16 +11,24 @@ const regEx_1 = require("./utils/regEx");
 const OpenEthereumClient_1 = __importDefault(require("./clients/OpenEthereumClient"));
 const EtherscanClient_1 = __importDefault(require("./clients/EtherscanClient"));
 const GethClient_1 = __importDefault(require("./clients/GethClient"));
+const commander_1 = require("commander");
 const debugControl = require("debug");
 const debug = require("debug")("tx2uml");
-const program = require("commander");
+const program = new commander_1.Command();
 program
     .arguments("<txHash>")
-    .usage(`<transaction hash or comma separated list of hashes> [options]
+    .description(`
+    Ethereum transaction visualizer that generates a UML sequence diagram of
+    transaction contract calls from an Ethereum archive node and Etherscan
+    API.
 
-Ethereum transaction visualizer that generates a UML sequence diagram of transaction contract calls from an Ethereum archive node and Etherscan API.
+    The transaction hashes have to be in hexadecimal format with a 0x
+    prefix. If running for multiple transactions, the comma-separated list
+    of transaction hashes must not have white spaces. eg spaces or tags.
+    `)
+    .usage(`<txhash(s)> [options]
 
-The transaction hashes have to be in hexadecimal format with a 0x prefix. If running for multiple transactions, the comma separated list of transaction hashes must not have white spaces. eg spaces or tags.`)
+    `)
     .option("-f, --outputFormat <value>", "output file format: png, svg, eps or puml", "png")
     .option("-o, --outputFileName <value>", "output file name. Defaults to the transaction hash.")
     .option("-u, --url <url>", "URL of the archive node with trace transaction support. Can also be set with the ARCHIVE_NODE_URL environment variable. (default: http://localhost:8545)")
@@ -35,8 +43,13 @@ The transaction hashes have to be in hexadecimal format with a 0x prefix. If run
     .option("-k, --etherscanKey <value>", "Etherscan API key. Register your API key at https://etherscan.io/myapikey")
     .option("-c, --chain <value>", "mainnet, polygon, ropsten, kovan, rinkeby or goerli", "mainnet")
     .option("-d, --depth <value>", "Limit the transaction call depth.")
-    .option("-v, --verbose", "run with debugging statements.", false)
-    .parse(process.argv);
+    .option("-v, --verbose", "run with debugging statements.", false);
+// addOption: Configure local environment settings by passing arguments to the shell interface
+// -eu where, -e=env and -u=url
+program.addOption(new commander_1.Option("-eu, --env-archivenode <string>", "specify archive node url for env configuration")
+    .default("http://localhost:8545")
+    .env("ARCHIVE_NODE_URL"));
+program.parse(process.argv);
 const options = program.opts();
 if (options.verbose) {
     debugControl.enable("tx2uml,axios");
@@ -107,7 +120,7 @@ const tx2uml = async () => {
     });
     transaction_1.TransactionManager.parseTraceDepths(transactionTraces, usedContracts);
     transactions.forEach(tx => transaction_1.TransactionManager.parseTransactionLogs(tx.logs, usedContracts));
-    pumlStream = plantUmlStreamer_1.streamTxPlantUml(transactions, transactionTraces, usedContracts, {
+    pumlStream = (0, plantUmlStreamer_1.streamTxPlantUml)(transactions, transactionTraces, usedContracts, {
         ...options,
         depth,
     });
@@ -117,7 +130,7 @@ const tx2uml = async () => {
             ? program.args[0]
             : "output";
     }
-    await fileGenerator_1.generateFile(pumlStream, {
+    await (0, fileGenerator_1.generateFile)(pumlStream, {
         format: options.outputFormat,
         filename,
     });
@@ -129,4 +142,5 @@ tx2uml()
     .catch(err => {
     console.error(`Failed to generate UML diagram ${err.stack}`);
 });
+/** @exports tx2uml */
 //# sourceMappingURL=tx2uml.js.map

--- a/lib/utils/formatters.js
+++ b/lib/utils/formatters.js
@@ -58,7 +58,7 @@ exports.formatNumber = formatNumber;
 const convertBytes32ToString = (output) => {
     if (!output || typeof output !== "string")
         return undefined;
-    return output.match(regEx_1.bytes) ? utils_1.parseBytes32String(output) : output;
+    return output.match(regEx_1.bytes) ? (0, utils_1.parseBytes32String)(output) : output;
 };
 exports.convertBytes32ToString = convertBytes32ToString;
 //# sourceMappingURL=formatters.js.map

--- a/lib/utils/transactionErrors.js
+++ b/lib/utils/transactionErrors.js
@@ -52,7 +52,7 @@ const getTransactionError = async (tx, receipt, provider) => {
             throw Error("Failed to parse error message from Ethereum call: " + e.message);
         }
     }
-    return exports.parseReasonCode(rawMessageData);
+    return (0, exports.parseReasonCode)(rawMessageData);
 };
 exports.getTransactionError = getTransactionError;
 const parseReasonCode = (messageData) => {
@@ -61,7 +61,7 @@ const parseReasonCode = (messageData) => {
     // Using the length and known offset, extract and convert the revert reason
     const reasonCodeHex = messageData.slice(8 + 128, 8 + 128 + strLen * 2);
     // Convert reason from hex to string
-    const reason = utils_1.toUtf8String("0x" + reasonCodeHex);
+    const reason = (0, utils_1.toUtf8String)("0x" + reasonCodeHex);
     return reason;
 };
 exports.parseReasonCode = parseReasonCode;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tx2uml",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Ethereum transaction visualizer that generates UML a sequence diagram from transaction contract calls.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
@@ -10,7 +10,10 @@
     "examples": "java -jar ./lib/plantuml.jar ./examples/syntax.puml ./examples/delegate.puml",
     "prettier:check": "prettier --check --no-semi '**/*.{ts,md}'",
     "prettier:fix": "prettier --write --no-semi '**/*.{ts,md}'",
-    "test": "npx jest"
+    "test": "npx jest -u",
+    "coverage": "npm test -- --coverage",
+    "debug-jest": "TS_JEST_LOG=ts-jest.log npx jest -u ",
+    "test-debug": "DEBUG_COLORS=1 NODE_ENV=test DEBUG=* npm run-script coverage"
   },
   "author": "Nick Addison",
   "repository": "github:naddison36/tx2uml",
@@ -41,19 +44,20 @@
     "visual"
   ],
   "dependencies": {
-    "axios": "^0.21.1",
+    "axios": "^0.23.0",
     "axios-debug-log": "^0.8.4",
     "bignumber.js": "^9.0.1",
-    "commander": "^8.1.0",
+    "commander": "^8.2.0",
     "debug": "^4.3.2",
-    "ethers": "^5.4.4",
-    "p-limit": "^3.1.0",
+    "ethers": "^5.4.7",
+    "p-limit": "3.1.0",
     "verror": "^1.10.0"
   },
   "devDependencies": {
     "@types/jest": "^27.0.1",
     "@types/node": "^16.6.1",
     "@types/verror": "^1.10.5",
+    "codecov": "^3.8.3",
     "jest": "^27.0.6",
     "prettier": "^2.3.2",
     "ts-jest": "^27.0.4",

--- a/src/ts/clients/EthereumNodeClient.ts
+++ b/src/ts/clients/EthereumNodeClient.ts
@@ -13,7 +13,7 @@ import {
 import { transactionHash } from "../utils/regEx"
 import { TokenInfo } from "../types/TokenInfo"
 
-require("axios-debug-log")
+require("axios-debug-log/enable")
 const debug = require("debug")("tx2uml")
 
 const tokenInfoAddress = "0xbA51331Bf89570F3f55BC26394fcCA05d4063C71"

--- a/src/ts/clients/EtherscanClient.ts
+++ b/src/ts/clients/EtherscanClient.ts
@@ -1,10 +1,10 @@
-import axios from "axios"
+const axios = require("axios").default
 import { BigNumber, Contract as EthersContract } from "ethers"
 import { VError } from "verror"
 
 import { Contract, Networks, Token } from "../transaction"
 import { ethereumAddress } from "../utils/regEx"
-
+require("axios-debug-log/enable")
 const debug = require("debug")("tx2uml")
 
 const etherscanBaseUrls = {

--- a/src/ts/clients/GethClient.ts
+++ b/src/ts/clients/GethClient.ts
@@ -1,4 +1,5 @@
-import axios from "axios"
+const axios = require("axios").default
+
 import { BigNumber } from "ethers"
 import { VError } from "verror"
 
@@ -7,7 +8,7 @@ import { transactionHash } from "../utils/regEx"
 import { hexlify, toUtf8String } from "ethers/lib/utils"
 import EthereumNodeClient from "./EthereumNodeClient"
 
-require("axios-debug-log")
+require("axios-debug-log/enable")
 const debug = require("debug")("tx2uml")
 
 export type CallResponse = {

--- a/src/ts/clients/OpenEthereumClient.ts
+++ b/src/ts/clients/OpenEthereumClient.ts
@@ -1,4 +1,4 @@
-import axios from "axios"
+const axios = require("axios").default
 import { BigNumber } from "ethers"
 import { VError } from "verror"
 
@@ -7,7 +7,7 @@ import { transactionHash } from "../utils/regEx"
 import { hexlify } from "ethers/lib/utils"
 import EthereumNodeClient from "./EthereumNodeClient"
 
-require("axios-debug-log")
+require("axios-debug-log/enable")
 const debug = require("debug")("tx2uml")
 
 export type TraceResponse = {

--- a/src/ts/tx2uml.ts
+++ b/src/ts/tx2uml.ts
@@ -9,19 +9,30 @@ import OpenEthereumClient from "./clients/OpenEthereumClient"
 import EtherscanClient from "./clients/EtherscanClient"
 import GethClient from "./clients/GethClient"
 import EthereumNodeClient from "./clients/EthereumNodeClient"
+import { Command, Option } from "commander"
 
 const debugControl = require("debug")
 const debug = require("debug")("tx2uml")
-const program = require("commander")
+
+const program = new Command()
 
 program
     .arguments("<txHash>")
+    .description(
+        `
+    Ethereum transaction visualizer that generates a UML sequence diagram of
+    transaction contract calls from an Ethereum archive node and Etherscan
+    API.
+
+    The transaction hashes have to be in hexadecimal format with a 0x
+    prefix. If running for multiple transactions, the comma-separated list
+    of transaction hashes must not have white spaces. eg spaces or tags.
+    `
+    )
     .usage(
-        `<transaction hash or comma separated list of hashes> [options]
+        `<txhash(s)> [options]
 
-Ethereum transaction visualizer that generates a UML sequence diagram of transaction contract calls from an Ethereum archive node and Etherscan API.
-
-The transaction hashes have to be in hexadecimal format with a 0x prefix. If running for multiple transactions, the comma separated list of transaction hashes must not have white spaces. eg spaces or tags.`
+    `
     )
     .option(
         "-f, --outputFormat <value>",
@@ -72,9 +83,21 @@ The transaction hashes have to be in hexadecimal format with a 0x prefix. If run
         "mainnet, polygon, ropsten, kovan, rinkeby or goerli",
         "mainnet"
     )
+
     .option("-d, --depth <value>", "Limit the transaction call depth.")
     .option("-v, --verbose", "run with debugging statements.", false)
-    .parse(process.argv)
+// addOption: Configure local environment settings by passing arguments to the shell interface
+// -eu where, -e=env and -u=url
+program.addOption(
+    new Option(
+        "-eu, --env-archivenode <string>",
+        "specify archive node url for env configuration"
+    )
+        .default("http://localhost:8545")
+        .env("ARCHIVE_NODE_URL")
+)
+
+program.parse(process.argv)
 
 const options = program.opts()
 
@@ -202,3 +225,4 @@ tx2uml()
     .catch(err => {
         console.error(`Failed to generate UML diagram ${err.stack}`)
     })
+/** @exports tx2uml */


### PR DESCRIPTION
### Feat: better debug output and coverage 

- axios import (this actually doesn't change much as the ts compiler fixes it, however can be misleading as Axios doesn't support ESM).

- axios-debug: use /enable so http traffic can be outputted in testing 

- add jest config types
- add codecov configuration
- update dependencies 
- tweak commander `--help` formatting
- add an option in the CLI to persist `ARCHIVE_NODE_URL` as an env setting



### Test issue

```sh
  console.error
    Failed to get token information for contracts: 0x1522900b6dafac587d499a862861c0869be6e428.
    error: invalid codepoint at offset 0; unexpected continuation byte (argument="bytes", value=Uint8Array(0x95d89b41), code=INVALID_ARGUMENT, version=strings/5.4.0)
```
[https://etherscan.io/address/0x1522900b6dafac587d499a862861c0869be6e428](https://etherscan.io/address/0x1522900b6dafac587d499a862861c0869be6e428)

This is not an ERC20 Contract, assuming this is suppose to be referencing a mainnet address. 

### Coverage Summary output

```
--------------------------|---------|----------|---------|---------|----------------------------------------------------------------------------------
File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                                
--------------------------|---------|----------|---------|---------|----------------------------------------------------------------------------------
All files                 |   45.45 |    40.92 |    37.6 |   44.54 |                                                                                  
 lib/clients              |       0 |        0 |       0 |       0 |                                                                                  
  ABIs.d.ts               |       0 |        0 |       0 |       0 |                                                                                  
  EthereumNodeClient.d.ts |       0 |        0 |       0 |       0 |                                                                                  
  EtherscanClient.d.ts    |       0 |        0 |       0 |       0 |                                                                                  
  GethClient.d.ts         |       0 |        0 |       0 |       0 |                                                                                  
  OpenEthereumClient.d.ts |       0 |        0 |       0 |       0 |                                                                                  
 lib/utils                |       0 |        0 |       0 |       0 |                                                                                  
  formatters.d.ts         |       0 |        0 |       0 |       0 |                                                                                  
  jest.d.ts               |       0 |        0 |       0 |       0 |                                                                                  
  regEx.d.ts              |       0 |        0 |       0 |       0 |                                                                                  
  transactionErrors.d.ts  |       0 |        0 |       0 |       0 |                                                                                  
 src/ts                   |   27.99 |    18.81 |      20 |   27.14 |                                                                                  
  fileGenerator.ts        |       0 |        0 |       0 |       0 | 1-52                                                                             
  index.ts                |       0 |      100 |     100 |       0 | 1-5                                                                              
  plantUmlStreamer.ts     |   47.69 |    40.38 |      50 |   46.23 | ...6,203,250,255-265,276-283,296,299,308,311-320,326,340,345-390,402,425,433-452 
  plantuml.ts             |   81.08 |       50 |   83.33 |      80 | 33-40,43,46,49,85                                                                
  transaction.ts          |   11.57 |     1.83 |    2.27 |   11.89 | 132-386,396-416,435-445,452-457,469-488,496-501,515-533,540-567,571-588,599-626  
  tx2uml.ts               |       0 |        0 |       0 |       0 | 4-226                                                                            
 src/ts/clients           |    80.8 |    60.86 |   91.66 |   80.48 |                                                                                  
  ABIs.ts                 |     100 |      100 |     100 |     100 |                                                                                  
  EthereumNodeClient.ts   |   92.85 |       50 |     100 |   92.68 | 37,75,127                                                                        
  EtherscanClient.ts      |   55.81 |    22.36 |   66.66 |   55.81 | 75-79,99-147                                                                     
  GethClient.ts           |   75.58 |    66.66 |   88.88 |      75 | 47,62,70,94,102,129-162,245-251                                                  
  OpenEthereumClient.ts   |    93.5 |    78.98 |     100 |   93.42 | 55,73,164,172,200                                                                
 src/ts/types             |       0 |        0 |       0 |       0 |                                                                                  
  TokenInfo.d.ts          |       0 |        0 |       0 |       0 |                                                                                  
 src/ts/utils             |   47.32 |    28.57 |   38.88 |   43.29 |                                                                                  
  formatters.ts           |   90.47 |    57.14 |   83.33 |    93.1 | 54-55                                                                            
  jest.ts                 |      30 |    22.22 |      20 |      30 | 17-67                                                                            
  regEx.ts                |     100 |      100 |     100 |     100 |                                                                                  
  transactionErrors.ts    |       0 |        0 |       0 |       0 | 3-84                                                                             
--------------------------|---------|----------|---------|---------|----------------------------------------------------------------------------------

=============================== Coverage summary ===============================
Statements   : 45.45% ( 400/880 )
Branches     : 40.92% ( 257/628 )
Functions    : 37.6% ( 44/117 )
Lines        : 44.54% ( 376/844 )
================================================================================
Test Suites: 1 failed, 4 passed, 5 total
Tests:       9 failed, 85 passed, 94 total
Snapshots:   0 total
Time:        154.112 s
Ran all test suites.
```

Signed-off-by: sam bacha <sam@manifoldfinance.com>