### PR TITLE
fixed README and remove using Etherscan for value flow diagrams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ package-lock.json
 output.png
 build/
 dist/
+tx.config.json

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ Usage: tx2uml call <txhash(s)> [options]
 UML sequence diagram of transaction contract calls. (default)
 
 Arguments:
-  txHash(s)                  Transaction hash or an array of hashes in hexadecimal format with a 0x prefix. If running for multiple transactions, the comma separated list of transaction hashes must not have white spaces.
+  txHash(s)                  Transaction hash or an array of hashes in hexadecimal format with a 0x prefix. If running for multiple transactions, the comma-separated list of transaction hashes must not have white spaces.
 
 Options:
-  -a, --noAddresses <value>  Hide calls to contracts in a list of comma separated addresses with a 0x prefix.
+  -a, --noAddresses <value>  Hide calls to contracts in a list of comma-separated addresses with a 0x prefix.
   -d, --depth <value>        Limit the transaction call depth.
   -e, --noEther              Hide ether values. (default: false)
   -g, --noGas                Hide gas usages. (default: false)
@@ -88,36 +88,19 @@ Options:
   -t, --noTxDetails          Hide transaction details like nonce, gas and tx fee. (default: false)
   -x, --noDelegates          Hide delegate calls from proxy contracts to their implementations and calls to deployed libraries. (default: false)
   -h, --help                 display help for command
-
 ```
 
 ### Value command
 
 ```
-Usage: tx2uml call <txhash(s)> [options]
-
-UML sequence diagram of transaction contract calls. (default)
-
-Arguments:
-  txHash(s)                  Transaction hash or an array of hashes in hexadecimal format with a 0x prefix. If running for multiple transactions, the comma separated list of transaction hashes must not have white spaces.
-
-Options:
-  -a, --noAddresses <value>  Hide calls to contracts in a list of comma separated addresses with a 0x prefix.
-  -d, --depth <value>        Limit the transaction call depth.
-  -e, --noEther              Hide ether values. (default: false)
-  -g, --noGas                Hide gas usages. (default: false)
-  -l, --noLogDetails         Hide log details emitted from contract events. (default: false)
-  -p, --noParams             Hide function params and return values. (default: false)
-  -t, --noTxDetails          Hide transaction details like nonce, gas and tx fee. (default: false)
-  -x, --noDelegates          Hide delegate calls from proxy contracts to their implementations and calls to deployed libraries. (default: false)
-  -h, --help                 display help for command
-workspaces/tx2uml % npx tx2uml value --help
 Usage: tx2uml value <txhash(s)> [options]
 
-UML sequence diagram of token and ether value transfers.
+Generates a UML sequence diagram of token and ether value transfers between accounts and contracts.
+
+This requires an archive node that supports debug_traceTransaction with custom EVM tracers which are Geth or Erigon.
 
 Arguments:
-  txHash(s)   Transaction hash or an array of hashes in hexadecimal format with a 0x prefix. If running for multiple transactions, the comma separated list of transaction hashes must not have white spaces.
+  txHash(s)   Transaction hash or an array of hashes in hexadecimal format with a 0x prefix. If running for multiple transactions, the comma-separated list of transaction hashes must not have white spaces.
 
 Options:
   -h, --help  display help for command

--- a/lib/transaction.d.ts
+++ b/lib/transaction.d.ts
@@ -59,15 +59,19 @@ export declare type Contract = {
     events?: Event[];
     minDepth?: number;
 };
+export declare type Contracts = {
+    [address: string]: Contract;
+};
 export declare type TokenDetails = {
     address: string;
     noContract: boolean;
     name?: string;
     symbol?: string;
     decimals?: number;
+    protocol?: string;
 };
-export declare type Contracts = {
-    [address: string]: Contract;
+export declare type Participants = {
+    [address: string]: TokenDetails;
 };
 export declare type Token = {
     address: string;
@@ -118,10 +122,10 @@ export declare class TransactionManager {
     getTransaction(txHash: string): Promise<TransactionDetails>;
     getTraces(transactions: TransactionDetails[]): Promise<Trace[][]>;
     getContractsFromTraces(transactionsTraces: Trace[][], configFilename?: string): Promise<Contracts>;
-    getContractsFromTransfers(transactionsTransfers: Transfer[][], configFilename?: string): Promise<Contracts>;
+    getTransferParticipants(transactionsTransfers: Transfer[][], configFilename?: string): Promise<Participants>;
     getContractsFromAddresses(addresses: string[]): Promise<Contracts>;
     setTokenAttributes(contracts: Contracts): Promise<void>;
-    configOverrides(contracts: Contracts, filename?: string): Promise<void>;
+    configOverrides(contracts: Contracts & Participants, filename?: string): Promise<void>;
     static parseTraceParams(traces: Trace[][], contracts: Contracts): void;
     static parseTransactionLogs(logs: Array<Log>, contracts: Contracts): void;
     static parseTraceDepths(traces: Trace[][], contracts: Contracts): void;

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -116,7 +116,7 @@ class TransactionManager {
         await this.configOverrides(contracts, configFilename);
         return contracts;
     }
-    async getContractsFromTransfers(transactionsTransfers, configFilename) {
+    async getTransferParticipants(transactionsTransfers, configFilename) {
         const flatTransfers = transactionsTransfers.flat();
         const addressSet = new Set();
         flatTransfers.forEach(transfer => {
@@ -126,12 +126,14 @@ class TransactionManager {
                 addressSet.add(transfer.tokenAddress);
         });
         const uniqueAddresses = Array.from(addressSet);
-        // get contract ABIs from Etherscan
-        const contracts = await this.getContractsFromAddresses(uniqueAddresses);
-        // Get token name and symbol from chain
-        await this.setTokenAttributes(contracts);
+        // get token details from on-chain
+        const participantDetails = await this.ethereumNodeClient.getTokenDetails(uniqueAddresses);
+        const participants = {};
+        participantDetails.forEach(p => {
+            participants[p.address] = p;
+        });
         // Override contract details like name, token symbol and ABI
-        await this.configOverrides(contracts, configFilename);
+        await this.configOverrides(participants, configFilename);
         // Add the token symbol and name to each transfer
         transactionsTransfers.forEach(transfers => {
             transfers.forEach(transfer => {
@@ -139,15 +141,15 @@ class TransactionManager {
                     transfer.decimals = 18;
                     return;
                 }
-                const contract = contracts[transfer.tokenAddress];
-                if (contract) {
-                    transfer.tokenSymbol = contract.symbol;
-                    transfer.tokenName = contract.tokenName;
-                    transfer.decimals = contract.decimals;
+                const tokenDetails = participants[transfer.tokenAddress];
+                if (tokenDetails) {
+                    transfer.tokenSymbol = tokenDetails.symbol;
+                    transfer.tokenName = tokenDetails.address;
+                    transfer.decimals = tokenDetails.decimals;
                 }
             });
         });
-        return contracts;
+        return participants;
     }
     // Get the contract names and ABIs from Etherscan
     async getContractsFromAddresses(addresses) {

--- a/lib/tx2uml.js
+++ b/lib/tx2uml.js
@@ -53,10 +53,10 @@ const version = (0, path_1.basename)(__dirname) === "lib"
 program.version(version);
 program
     .command("call", { isDefault: true })
-    .argument("<txHash(s)>", "Transaction hash or an array of hashes in hexadecimal format with a 0x prefix. If running for multiple transactions, the comma separated list of transaction hashes must not have white spaces.")
+    .argument("<txHash(s)>", "Transaction hash or an array of hashes in hexadecimal format with a 0x prefix. If running for multiple transactions, the comma-separated list of transaction hashes must not have white spaces.")
     .usage("<txhash(s)> [options]")
     .description("Generates a UML sequence diagram of transaction contract calls between contracts. (default)")
-    .option("-a, --noAddresses <value>", "Hide calls to contracts in a list of comma separated addresses with a 0x prefix.")
+    .option("-a, --noAddresses <value>", "Hide calls to contracts in a list of comma-separated addresses with a 0x prefix.")
     .option("-d, --depth <value>", "Limit the transaction call depth.")
     .option("-e, --noEther", "Hide ether values.", false)
     .option("-g, --noGas", "Hide gas usages.", false)
@@ -79,9 +79,11 @@ program
 });
 program
     .command("value")
-    .argument("<txHash(s)>", "Transaction hash or an array of hashes in hexadecimal format with a 0x prefix. If running for multiple transactions, the comma separated list of transaction hashes must not have white spaces.")
+    .argument("<txHash(s)>", "Transaction hash or an array of hashes in hexadecimal format with a 0x prefix. If running for multiple transactions, the comma-separated list of transaction hashes must not have white spaces.")
     .usage("<txhash(s)> [options]")
-    .description("Generates a UML sequence diagram of token and ether value transfers between accounts and contracts.")
+    .description(`Generates a UML sequence diagram of token and ether value transfers between accounts and contracts.
+
+This requires an archive node that supports debug_traceTransaction with custom EVM tracers which is Geth or Erigon.`)
     .action(async (hashes, options, command) => {
     debug(`About to generate tx calls for ${hashes}`);
     try {

--- a/lib/valueDiagram.js
+++ b/lib/valueDiagram.js
@@ -87,7 +87,7 @@ const generateValueDiagram = async (hashes, options) => {
         }
     });
     // Get all the participating contracts from the transfers
-    const contracts = await txManager.getContractsFromTransfers(transfers, options.configFile);
+    const contracts = await txManager.getTransferParticipants(transfers, options.configFile);
     // Convert transactions and transfers to readable stream
     const pumlStream = (0, transfersPumlStreamer_1.transfers2PumlStream)(transactions, transfers, contracts);
     // Pipe readable stream to PlantUML's Java process which then writes to a file

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tx2uml",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Ethereum transaction visualizer that generates UML sequence diagrams.",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/ts/tx2uml.ts
+++ b/src/ts/tx2uml.ts
@@ -89,7 +89,7 @@ program
     .command("call", { isDefault: true })
     .argument(
         "<txHash(s)>",
-        "Transaction hash or an array of hashes in hexadecimal format with a 0x prefix. If running for multiple transactions, the comma separated list of transaction hashes must not have white spaces."
+        "Transaction hash or an array of hashes in hexadecimal format with a 0x prefix. If running for multiple transactions, the comma-separated list of transaction hashes must not have white spaces."
     )
     .usage("<txhash(s)> [options]")
     .description(
@@ -97,7 +97,7 @@ program
     )
     .option(
         "-a, --noAddresses <value>",
-        "Hide calls to contracts in a list of comma separated addresses with a 0x prefix."
+        "Hide calls to contracts in a list of comma-separated addresses with a 0x prefix."
     )
     .option("-d, --depth <value>", "Limit the transaction call depth.")
     .option("-e, --noEther", "Hide ether values.", false)
@@ -136,11 +136,13 @@ program
     .command("value")
     .argument(
         "<txHash(s)>",
-        "Transaction hash or an array of hashes in hexadecimal format with a 0x prefix. If running for multiple transactions, the comma separated list of transaction hashes must not have white spaces."
+        "Transaction hash or an array of hashes in hexadecimal format with a 0x prefix. If running for multiple transactions, the comma-separated list of transaction hashes must not have white spaces."
     )
     .usage("<txhash(s)> [options]")
     .description(
-        "Generates a UML sequence diagram of token and ether value transfers between accounts and contracts."
+        `Generates a UML sequence diagram of token and ether value transfers between accounts and contracts.
+
+This requires an archive node that supports debug_traceTransaction with custom EVM tracers which are Geth or Erigon.`
     )
     .action(async (hashes: string, options, command) => {
         debug(`About to generate tx calls for ${hashes}`)

--- a/src/ts/valueDiagram.ts
+++ b/src/ts/valueDiagram.ts
@@ -101,13 +101,17 @@ export const generateValueDiagram = async (hashes: string, options: any) => {
     })
 
     // Get all the participating contracts from the transfers
-    const contracts = await txManager.getContractsFromTransfers(
+    const participants = await txManager.getTransferParticipants(
         transfers,
         options.configFile
     )
 
     // Convert transactions and transfers to readable stream
-    const pumlStream = transfers2PumlStream(transactions, transfers, contracts)
+    const pumlStream = transfers2PumlStream(
+        transactions,
+        transfers,
+        participants
+    )
 
     // Pipe readable stream to PlantUML's Java process which then writes to a file
     let filename = options.outputFileName


### PR DESCRIPTION
* fixed value usage in README
* no longer download contract source code and ABIs from Etherscan for value transfer diagrams