### PR TITLE
feat: allow generic abi as an alternative to config and etherscan

### DIFF
--- a/lib/callDiagram.js
+++ b/lib/callDiagram.js
@@ -29,7 +29,7 @@ const generateCallDiagram = async (hashes, options) => {
     const txManager = new transaction_1.TransactionManager(ethereumNodeClient, etherscanClient);
     let transactions = await txManager.getTransactions(hashes, options.chain);
     const transactionTracesUnfiltered = await txManager.getTraces(transactions);
-    const contracts = await txManager.getContractsFromTraces(transactionTracesUnfiltered, options.configFile, options.chain);
+    const contracts = await txManager.getContractsFromTraces(transactionTracesUnfiltered, options.configFile, options.abiFile, options.chain);
     transaction_1.TransactionManager.parseTraceParams(transactionTracesUnfiltered, contracts);
     const [transactionTraces, usedContracts] = transaction_1.TransactionManager.filterTransactionTraces(transactionTracesUnfiltered, contracts, {
         ...options,

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -28,3 +28,4 @@ export interface ContractsConfig {
     [address: string]: ContractConfig;
 }
 export declare const loadConfig: (fileName?: string) => Promise<ContractsConfig>;
+export declare const loadGenericAbi: (fileName?: string) => Promise<ReadonlyArray<JsonFragment>>;

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.loadConfig = void 0;
+exports.loadGenericAbi = exports.loadConfig = void 0;
 const fs_1 = require("fs");
 const debug = require("debug")("tx2uml");
 const loadConfig = async (fileName = "./tx.config.json") => {
@@ -12,4 +12,13 @@ const loadConfig = async (fileName = "./tx.config.json") => {
     return config;
 };
 exports.loadConfig = loadConfig;
+const loadGenericAbi = async (fileName = "./tx.abi.json") => {
+    let abi = [];
+    if ((0, fs_1.existsSync)(fileName)) {
+        abi = JSON.parse((0, fs_1.readFileSync)(fileName, "utf-8"));
+        debug(`loaded generic abi file ${fileName}`);
+    }
+    return abi;
+};
+exports.loadGenericAbi = loadGenericAbi;
 //# sourceMappingURL=config.js.map

--- a/lib/transaction.d.ts
+++ b/lib/transaction.d.ts
@@ -10,8 +10,9 @@ export declare class TransactionManager {
     getTransactions(txHashes: string[], network: string): Promise<TransactionDetails[]>;
     getTransaction(txHash: string): Promise<TransactionDetails>;
     getTraces(transactions: TransactionDetails[]): Promise<Trace[][]>;
-    getContractsFromTraces(transactionsTraces: Trace[][], configFilename?: string, network?: Network): Promise<Contracts>;
+    getContractsFromTraces(transactionsTraces: Trace[][], configFilename?: string, abiFilename?: string, network?: Network): Promise<Contracts>;
     getTransferParticipants(transactionsTransfers: Transfer[][], block: number, network: Network, configFilename?: string): Promise<Participants>;
+    fillContractsABIFromAddresses(contracts: Contracts & Participants, addresses: string[], abiFilename: string): Promise<void>;
     getContractsFromAddresses(addresses: string[]): Promise<Contracts>;
     setTokenAttributes(contracts: Contracts, network: Network): Promise<void>;
     configOverrides(contracts: Contracts & Participants, filename?: string): Promise<void>;

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -37,7 +37,7 @@ class TransactionManager {
         }
         return transactionsTraces;
     }
-    async getContractsFromTraces(transactionsTraces, configFilename, network = "mainnet") {
+    async getContractsFromTraces(transactionsTraces, configFilename, abiFilename, network = "mainnet") {
         const flatTraces = transactionsTraces.flat();
         const participantAddresses = [];
         // for each contract, maps all the contract addresses it can delegate to.
@@ -83,6 +83,8 @@ class TransactionManager {
         await this.setTokenAttributes(contracts, network);
         // Override contract details like name, token symbol and ABI
         await this.configOverrides(contracts, configFilename);
+        // Override abi information with a generic abi
+        await this.fillContractsABIFromAddresses(contracts, uniqueAddresses, abiFilename);
         return contracts;
     }
     async getTransferParticipants(transactionsTransfers, block, network, configFilename) {
@@ -140,6 +142,19 @@ class TransactionManager {
             });
         });
         return participants;
+    }
+    // Map contract ABI from generic abi
+    async fillContractsABIFromAddresses(contracts, addresses, abiFilename) {
+        const abis = await (0, config_1.loadGenericAbi)(abiFilename);
+        const originalLog = console.log;
+        console.log = function () { };
+        for (const address of addresses) {
+            if (!contracts[address].ethersContract) {
+                contracts[address].ethersContract = new ethers_1.Contract(address, abis);
+                contracts[address].events = [];
+            }
+        }
+        console.log = originalLog;
     }
     // Get the contract names and ABIs from Etherscan
     async getContractsFromAddresses(addresses) {

--- a/lib/tx2uml.js
+++ b/lib/tx2uml.js
@@ -26,6 +26,7 @@ program
     .default("mainnet")
     .env("ETH_NETWORK"))
     .option("-cf, --configFile <value>", "name of the json configuration file that can override contract details like name and ABI", "tx.config.json")
+    .option("-af, --abiFile <value>", "name of the json abi file that can override contract details like ABI", "tx.abi.json")
     .option("-m, --memory <gigabytes>", "max Java memory of PlantUML process in gigabytes. Java default is 1/4 of physical memory. Large txs in png format will need up to 12g. svg format is much better for large transactions.")
     .option("-v, --verbose", "run with debugging statements", false);
 const version = (0, path_1.basename)(__dirname) === "lib"

--- a/lib/types/tx2umlTypes.d.ts
+++ b/lib/types/tx2umlTypes.d.ts
@@ -182,6 +182,7 @@ export interface CallDiagramOptions extends TracePumlGenerationOptions {
     noAddresses?: string[];
     etherscanKey?: string;
     configFile?: string;
+    abiFile?: string;
 }
 export interface TransferPumlGenerationOptions extends OutputOptions {
     chain?: Network;

--- a/src/ts/callDiagram.ts
+++ b/src/ts/callDiagram.ts
@@ -45,6 +45,7 @@ export const generateCallDiagram = async (
     const contracts = await txManager.getContractsFromTraces(
         transactionTracesUnfiltered,
         options.configFile,
+        options.abiFile,
         options.chain
     )
     TransactionManager.parseTraceParams(transactionTracesUnfiltered, contracts)

--- a/src/ts/config.ts
+++ b/src/ts/config.ts
@@ -50,3 +50,14 @@ export const loadConfig = async (
 
     return config
 }
+
+export const loadGenericAbi = async (
+    fileName: string = "./tx.abi.json"
+): Promise<ReadonlyArray<JsonFragment>> => {
+    let abi: ReadonlyArray<JsonFragment> = []
+    if (existsSync(fileName)) {
+        abi = JSON.parse(readFileSync(fileName, "utf-8"))
+        debug(`loaded generic abi file ${fileName}`)
+    }
+    return abi
+}

--- a/src/ts/tx2uml.ts
+++ b/src/ts/tx2uml.ts
@@ -55,6 +55,11 @@ program
         "tx.config.json"
     )
     .option(
+        "-af, --abiFile <value>",
+        "name of the json abi file that can override contract details like ABI",
+        "tx.abi.json"
+    )
+    .option(
         "-m, --memory <gigabytes>",
         "max Java memory of PlantUML process in gigabytes. Java default is 1/4 of physical memory. Large txs in png format will need up to 12g. svg format is much better for large transactions."
     )

--- a/src/ts/types/tx2umlTypes.ts
+++ b/src/ts/types/tx2umlTypes.ts
@@ -236,6 +236,7 @@ export interface CallDiagramOptions extends TracePumlGenerationOptions {
     noAddresses?: string[]
     etherscanKey?: string
     configFile?: string
+    abiFile?: string
 }
 
 export interface TransferPumlGenerationOptions extends OutputOptions {


### PR DESCRIPTION
Not all contracts are registered in Etherscan, and it might be cumbersome to register them in the config file per address. For convenience, users have a second option to pass in a generic ABI that can parse against majority of the contracts that they are concerned about.